### PR TITLE
Update actions to latest versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,9 +51,9 @@ jobs:
         with:
           command: build
           args: --release --all-features
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: plotsweep ${{ matrix.os }}
+          name: plotsweep ${{ matrix.os }} rust-${{ matrix.rust }}
           path: |
             target/release/plotsweep
             target/release/plotsweep.exe

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
         rust: ['stable']
         include:
           - os: 'ubuntu-20.04'
-            rust: '1.41'
+            rust: '1.63'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,18 +18,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install stable components
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: clippy
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
 
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --verbose --release -- -D warnings
+        run: cargo clippy -- --deny warnings
 
   build_and_test:
     name: Rust project
@@ -44,13 +39,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+      - name: Build
+        run: cargo build --release
       - uses: actions/upload-artifact@v4
         with:
           name: plotsweep ${{ matrix.os }} rust-${{ matrix.rust }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable components
         uses: actions-rs/toolchain@v1
@@ -43,7 +43,7 @@ jobs:
             rust: '1.41'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}


### PR DESCRIPTION
* Update upload-artifact from v2 to v4 to fix deprecation error.
* Update checkout from v2 to v4
* Update MSRV to 1.63 from 1.41
* Replace Rust actions with direct use of rustup and cargo to remove a lot of deprecation warnings. This also fixes a bug where the MSRV wasn't actually being tested.